### PR TITLE
feat(photon-oval): add Photon OS OVAL vulnerability source

### DIFF
--- a/pkg/vulnsrc/photon-oval/photon_oval.go
+++ b/pkg/vulnsrc/photon-oval/photon_oval.go
@@ -1,0 +1,197 @@
+package photonoval
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/samber/oops"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/log"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bucket"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+const photonOvalDir = "photon-oval"
+
+var source = types.DataSource{
+	ID:   vulnerability.PhotonOVAL,
+	Name: "Photon OS OVAL definitions",
+	URL:  "https://packages.broadcom.com/photon/photon_oval/",
+}
+
+// VulnSrc implements the VulnSrc interface for Photon OS OVAL advisories
+type VulnSrc struct {
+	dbc    db.Operation
+	logger *log.Logger
+}
+
+// NewVulnSrc returns a new VulnSrc for Photon OS OVAL
+func NewVulnSrc() VulnSrc {
+	return VulnSrc{
+		dbc:    db.Config{},
+		logger: log.WithPrefix("photon-oval"),
+	}
+}
+
+// Name returns the source ID
+func (vs VulnSrc) Name() types.SourceID {
+	return source.ID
+}
+
+// Update walks the photon/oval directory tree and stores all advisories to BoltDB
+func (vs VulnSrc) Update(dir string) error {
+	rootDir := filepath.Join(dir, "vuln-list", photonOvalDir)
+	eb := oops.In("photon-oval").With("root_dir", rootDir)
+
+	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		// Extract OS version from path segment, e.g. ".../photon/oval/5.0/PHSA-....json" -> "5.0"
+		osVer, err := osVersionFromPath(rootDir, path)
+		if err != nil {
+			return eb.With("file_path", path).Wrapf(err, "failed to extract OS version from path")
+		}
+
+		var oval PhotonOVAL
+		if err = json.NewDecoder(r).Decode(&oval); err != nil {
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
+		}
+
+		if err = vs.save(osVer, oval); err != nil {
+			return eb.With("file_path", path).Wrapf(err, "save error")
+		}
+		return nil
+	})
+	if err != nil {
+		return eb.Wrapf(err, "walk error")
+	}
+	return nil
+}
+
+// osVersionFromPath extracts the OS version segment from the file path.
+// Given rootDir = ".../photon/oval" and path = ".../photon/oval/5.0/PHSA-2023-0001.json",
+// the function returns "5.0".
+func osVersionFromPath(rootDir, path string) (string, error) {
+	rel, err := filepath.Rel(rootDir, path)
+	if err != nil {
+		return "", err
+	}
+	// rel is like "5.0/PHSA-2023-0001.json"
+	parts := strings.SplitN(rel, string(filepath.Separator), 2)
+	if len(parts) < 2 {
+		return "", oops.Errorf("unexpected path structure: %s", path)
+	}
+	return parts[0], nil
+}
+
+func (vs VulnSrc) save(osVer string, oval PhotonOVAL) error {
+	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
+		return vs.commit(tx, osVer, oval)
+	})
+	if err != nil {
+		return oops.Wrapf(err, "batch update error")
+	}
+	return nil
+}
+
+func (vs VulnSrc) commit(tx *bolt.Tx, osVer string, oval PhotonOVAL) error {
+	platform := platformName(osVer)
+
+	if err := vs.dbc.PutDataSource(tx, platform, source); err != nil {
+		return oops.With("platform", platform).Wrapf(err, "failed to put data source")
+	}
+
+	pkgs := parsePackages(oval.Criteria)
+	if len(pkgs) == 0 {
+		return nil
+	}
+
+	sev := mapSeverity(oval.Severity)
+
+	for _, cve := range oval.Cves {
+		if cve.ID == "" {
+			continue
+		}
+
+		vuln := types.VulnerabilityDetail{
+			Severity: sev,
+		}
+		if err := vs.dbc.PutVulnerabilityDetail(tx, cve.ID, source.ID, vuln); err != nil {
+			return oops.With("cve_id", cve.ID).Wrapf(err, "failed to save vulnerability detail")
+		}
+
+		if err := vs.dbc.PutVulnerabilityID(tx, cve.ID); err != nil {
+			return oops.With("cve_id", cve.ID).Wrapf(err, "failed to save vulnerability ID")
+		}
+
+		for _, pkg := range pkgs {
+			advisory := types.Advisory{
+				FixedVersion: pkg.FixedVersion,
+			}
+			if err := vs.dbc.PutAdvisoryDetail(tx, cve.ID, pkg.Name, []string{platform}, advisory); err != nil {
+				return oops.With("cve_id", cve.ID).With("pkg", pkg.Name).Wrapf(err, "failed to save advisory")
+			}
+		}
+	}
+	return nil
+}
+
+// parsePackages walks the Criteria tree and extracts all affected packages with fixed versions.
+// It matches criterion comments of the form "{pkg} is earlier than 0:{ver}"
+// and skips "is signed with VMware key" lines.
+func parsePackages(criteria Criteria) []AffectedPackage {
+	var pkgs []AffectedPackage
+	for _, c := range criteria.Criterions {
+		ss := strings.Split(c.Comment, " is earlier than ")
+		if len(ss) != 2 {
+			continue
+		}
+		pkgName := strings.TrimSpace(ss[0])
+		rawVer := strings.TrimSpace(ss[1])
+		// Strip the leading "0:" epoch prefix if present
+		fixedVersion := strings.TrimPrefix(rawVer, "0:")
+		pkgs = append(pkgs, AffectedPackage{
+			Name:         pkgName,
+			FixedVersion: fixedVersion,
+		})
+	}
+	for _, sub := range criteria.Criterias { //nolint:misspell
+		pkgs = append(pkgs, parsePackages(sub)...)
+	}
+	return pkgs
+}
+
+// mapSeverity maps a Photon OVAL severity string to a types.Severity value
+func mapSeverity(sev string) types.Severity {
+	switch sev {
+	case "Critical":
+		return types.SeverityCritical
+	case "Important":
+		return types.SeverityHigh
+	case "Moderate":
+		return types.SeverityMedium
+	case "Low":
+		return types.SeverityLow
+	}
+	return types.SeverityUnknown
+}
+
+// platformName returns the BoltDB bucket name for a given Photon OS version
+func platformName(osVer string) string {
+	return bucket.NewPhoton(osVer).Name()
+}
+
+// Get returns advisories for a given Photon OS release and package name
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("photon-oval").With("release", params.Release)
+	platform := platformName(params.Release)
+	advisories, err := vs.dbc.GetAdvisories(platform, params.PkgName)
+	if err != nil {
+		return nil, eb.Wrapf(err, "failed to get advisories")
+	}
+	return advisories, nil
+}

--- a/pkg/vulnsrc/photon-oval/photon_oval_test.go
+++ b/pkg/vulnsrc/photon-oval/photon_oval_test.go
@@ -1,0 +1,192 @@
+package photonoval_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	photonoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/photon-oval"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
+)
+
+func TestMain(m *testing.M) {
+	utils.Quiet = true
+	os.Exit(m.Run())
+}
+
+func TestVulnSrc_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		dir        string
+		wantValues []vulnsrctest.WantValues
+		wantErr    string
+	}{
+		{
+			name: "happy path",
+			dir:  filepath.Join("testdata", "happy"),
+			wantValues: []vulnsrctest.WantValues{
+				// Photon OS 5.0 data source
+				{
+					Key: []string{"data-source", "Photon OS 5.0"},
+					Value: types.DataSource{
+						ID:   vulnerability.PhotonOVAL,
+						Name: "Photon OS OVAL definitions",
+						URL:  "https://packages.broadcom.com/photon/photon_oval/",
+					},
+				},
+				// libcap advisory for CVE-2023-2602
+				{
+					Key: []string{"advisory-detail", "CVE-2023-2602", "Photon OS 5.0", "libcap"},
+					Value: types.Advisory{
+						FixedVersion: "2.66-2.ph5",
+					},
+				},
+				// libcap-devel advisory for CVE-2023-2602
+				{
+					Key: []string{"advisory-detail", "CVE-2023-2602", "Photon OS 5.0", "libcap-devel"},
+					Value: types.Advisory{
+						FixedVersion: "2.66-2.ph5",
+					},
+				},
+				// libcap advisory for CVE-2023-2603
+				{
+					Key: []string{"advisory-detail", "CVE-2023-2603", "Photon OS 5.0", "libcap"},
+					Value: types.Advisory{
+						FixedVersion: "2.66-2.ph5",
+					},
+				},
+				// libcap-devel advisory for CVE-2023-2603
+				{
+					Key: []string{"advisory-detail", "CVE-2023-2603", "Photon OS 5.0", "libcap-devel"},
+					Value: types.Advisory{
+						FixedVersion: "2.66-2.ph5",
+					},
+				},
+				// vulnerability details
+				{
+					Key: []string{"vulnerability-detail", "CVE-2023-2602", "photon-oval"},
+					Value: types.VulnerabilityDetail{
+						Severity: types.SeverityHigh,
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2023-2603", "photon-oval"},
+					Value: types.VulnerabilityDetail{
+						Severity: types.SeverityHigh,
+					},
+				},
+				// vulnerability IDs
+				{
+					Key:   []string{"vulnerability-id", "CVE-2023-2602"},
+					Value: map[string]any{},
+				},
+				{
+					Key:   []string{"vulnerability-id", "CVE-2023-2603"},
+					Value: map[string]any{},
+				},
+				// Photon OS 4.0 data source
+				{
+					Key: []string{"data-source", "Photon OS 4.0"},
+					Value: types.DataSource{
+						ID:   vulnerability.PhotonOVAL,
+						Name: "Photon OS OVAL definitions",
+						URL:  "https://packages.broadcom.com/photon/photon_oval/",
+					},
+				},
+				// curl advisory for CVE-2023-23914 (Moderate -> Medium)
+				{
+					Key: []string{"advisory-detail", "CVE-2023-23914", "Photon OS 4.0", "curl"},
+					Value: types.Advisory{
+						FixedVersion: "7.87.0-3.ph4",
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2023-23914", "photon-oval"},
+					Value: types.VulnerabilityDetail{
+						Severity: types.SeverityMedium,
+					},
+				},
+				{
+					Key:   []string{"vulnerability-id", "CVE-2023-23914"},
+					Value: map[string]any{},
+				},
+			},
+		},
+		{
+			name:    "sad path (dir doesn't exist)",
+			dir:     filepath.Join("testdata", "badPath"),
+			wantErr: "no such file or directory",
+		},
+		{
+			name:    "sad path (failed to decode)",
+			dir:     filepath.Join("testdata", "sad"),
+			wantErr: "json decode error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := photonoval.NewVulnSrc()
+			vulnsrctest.TestUpdate(t, vs, vulnsrctest.TestUpdateArgs{
+				Dir:        tt.dir,
+				WantValues: tt.wantValues,
+				WantErr:    tt.wantErr,
+			})
+		})
+	}
+}
+
+func TestVulnSrc_Get(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixtures []string
+		release string
+		pkgName string
+		want    []types.Advisory
+		wantErr string
+	}{
+		{
+			name:     "happy path",
+			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			release:  "5.0",
+			pkgName:  "libcap",
+			want: []types.Advisory{
+				{
+					VulnerabilityID: "CVE-2023-2602",
+					FixedVersion:    "2.66-2.ph5",
+				},
+			},
+		},
+		{
+			name:     "no advisories are returned",
+			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			release:  "5.0",
+			pkgName:  "no-such-package",
+			want:     nil,
+		},
+		{
+			name:     "GetAdvisories returns an error",
+			fixtures: []string{"testdata/fixtures/sad.yaml"},
+			release:  "5.0",
+			pkgName:  "libcap",
+			wantErr:  "json unmarshal error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := photonoval.NewVulnSrc()
+			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
+				Fixtures:   tt.fixtures,
+				WantValues: tt.want,
+				GetParams: db.GetParams{
+					Release: tt.release,
+					PkgName: tt.pkgName,
+				},
+				WantErr: tt.wantErr,
+			})
+		})
+	}
+}

--- a/pkg/vulnsrc/photon-oval/testdata/fixtures/happy.yaml
+++ b/pkg/vulnsrc/photon-oval/testdata/fixtures/happy.yaml
@@ -1,0 +1,7 @@
+- bucket: Photon OS 5.0
+  pairs:
+    - bucket: libcap
+      pairs:
+        - key: CVE-2023-2602
+          value:
+            FixedVersion: "2.66-2.ph5"

--- a/pkg/vulnsrc/photon-oval/testdata/fixtures/sad.yaml
+++ b/pkg/vulnsrc/photon-oval/testdata/fixtures/sad.yaml
@@ -1,0 +1,6 @@
+- bucket: Photon OS 5.0
+  pairs:
+    - bucket: libcap
+      pairs:
+        - key: CVE-2023-2602
+          value: "not-a-valid-advisory-object"

--- a/pkg/vulnsrc/photon-oval/testdata/happy/vuln-list/photon-oval/4.0/PHSA-2023-4001.json
+++ b/pkg/vulnsrc/photon-oval/testdata/happy/vuln-list/photon-oval/4.0/PHSA-2023-4001.json
@@ -1,0 +1,35 @@
+{
+  "Title": "PHSA-2023:4001 curl Security Update. (Moderate)",
+  "Description": "An update for curl is now available for Photon OS 4.0.",
+  "Platform": ["Photon 4"],
+  "References": [
+    {"Source": "PHSA", "URI": "https://packages.broadcom.com/photon/photon_oval/4.0/PHSA-2023-4001.json", "ID": "PHSA:4001:4.0:20"},
+    {"Source": "CVE",  "URI": "https://nvd.nist.gov/vuln/detail/CVE-2023-23914", "ID": "CVE:00001:CVE-2023-23914"}
+  ],
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": [
+          {
+            "Operator": "AND",
+            "Criterias": null,
+            "Criterions": [
+              {"Comment": "curl is earlier than 0:7.87.0-3.ph4"},
+              {"Comment": "curl is signed with VMware key"}
+            ]
+          }
+        ],
+        "Criterions": null
+      }
+    ],
+    "Criterions": [{"Comment": "Photon OS 4 is installed"}]
+  },
+  "Severity": "Moderate",
+  "Cves": [
+    {"ID": "CVE-2023-23914"}
+  ],
+  "Issued":  {"Date": "2023-02-23"},
+  "Updated": {"Date": "2023-02-23"}
+}

--- a/pkg/vulnsrc/photon-oval/testdata/happy/vuln-list/photon-oval/5.0/PHSA-2023-5001.json
+++ b/pkg/vulnsrc/photon-oval/testdata/happy/vuln-list/photon-oval/5.0/PHSA-2023-5001.json
@@ -1,0 +1,45 @@
+{
+  "Title": "PHSA-2023:5001 libcap Security Update. (Important)",
+  "Description": "An update for libcap is now available for Photon OS 5.0.",
+  "Platform": ["Photon 5"],
+  "References": [
+    {"Source": "PHSA", "URI": "https://packages.broadcom.com/photon/photon_oval/5.0/PHSA-2023-5001.json", "ID": "PHSA:5001:5.0:20"},
+    {"Source": "CVE",  "URI": "https://nvd.nist.gov/vuln/detail/CVE-2023-2602", "ID": "CVE:00001:CVE-2023-2602"},
+    {"Source": "CVE",  "URI": "https://nvd.nist.gov/vuln/detail/CVE-2023-2603", "ID": "CVE:00001:CVE-2023-2603"}
+  ],
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": [
+          {
+            "Operator": "AND",
+            "Criterias": null,
+            "Criterions": [
+              {"Comment": "libcap is earlier than 0:2.66-2.ph5"},
+              {"Comment": "libcap is signed with VMware key"}
+            ]
+          },
+          {
+            "Operator": "AND",
+            "Criterias": null,
+            "Criterions": [
+              {"Comment": "libcap-devel is earlier than 0:2.66-2.ph5"},
+              {"Comment": "libcap-devel is signed with VMware key"}
+            ]
+          }
+        ],
+        "Criterions": null
+      }
+    ],
+    "Criterions": [{"Comment": "Photon OS 5 is installed"}]
+  },
+  "Severity": "Important",
+  "Cves": [
+    {"ID": "CVE-2023-2602"},
+    {"ID": "CVE-2023-2603"}
+  ],
+  "Issued":  {"Date": "2023-06-07"},
+  "Updated": {"Date": "2023-06-07"}
+}

--- a/pkg/vulnsrc/photon-oval/testdata/sad/vuln-list/photon-oval/5.0/badjson.json
+++ b/pkg/vulnsrc/photon-oval/testdata/sad/vuln-list/photon-oval/5.0/badjson.json
@@ -1,0 +1,1 @@
+this is not valid json {{{

--- a/pkg/vulnsrc/photon-oval/types.go
+++ b/pkg/vulnsrc/photon-oval/types.go
@@ -1,0 +1,49 @@
+package photonoval
+
+// PhotonOVAL represents a Photon OS OVAL advisory JSON file
+type PhotonOVAL struct {
+	Title       string      `json:"Title"`
+	Description string      `json:"Description"`
+	Platform    []string    `json:"Platform"`
+	References  []Reference `json:"References"`
+	Criteria    Criteria    `json:"Criteria"`
+	Severity    string      `json:"Severity"`
+	Cves        []Cve       `json:"Cves"`
+	Issued      Date        `json:"Issued"`
+	Updated     Date        `json:"Updated"`
+}
+
+// Reference represents a reference link in the advisory
+type Reference struct {
+	Source string `json:"Source"`
+	URI    string `json:"URI"`
+	ID     string `json:"ID"`
+}
+
+// Cve represents a CVE entry within the advisory
+type Cve struct {
+	ID string `json:"ID"`
+}
+
+// Criteria represents the OVAL criteria tree
+type Criteria struct {
+	Operator   string     `json:"Operator"`
+	Criterias  []Criteria `json:"Criterias"` //nolint:misspell
+	Criterions []Criterion `json:"Criterions"`
+}
+
+// Criterion represents a single OVAL criterion
+type Criterion struct {
+	Comment string `json:"Comment"`
+}
+
+// Date represents a date in an OVAL advisory
+type Date struct {
+	Date string `json:"Date"`
+}
+
+// AffectedPackage holds a parsed package name and its fixed version
+type AffectedPackage struct {
+	Name         string
+	FixedVersion string
+}

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -24,6 +24,7 @@ const (
 	AzureLinux            types.SourceID = "azure"
 	CBLMariner            types.SourceID = "cbl-mariner"
 	Photon                types.SourceID = "photon"
+	PhotonOVAL            types.SourceID = "photon-oval"
 	RubySec               types.SourceID = "ruby-advisory-db"
 	PhpSecurityAdvisories types.SourceID = "php-security-advisories"
 	NodejsSecurityWg      types.SourceID = "nodejs-security-wg"
@@ -59,6 +60,7 @@ var AllSourceIDs = []types.SourceID{
 	OracleOVAL,
 	SuseCVRF,
 	Photon,
+	PhotonOVAL,
 	ArchLinux,
 	Alma,
 	Rocky,

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/nvd"
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/photon"
+	photonoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/photon-oval"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat"
 	redhatoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
@@ -57,6 +58,7 @@ var (
 		susecvrf.NewVulnSrc(susecvrf.SUSEEnterpriseLinux),
 		susecvrf.NewVulnSrc(susecvrf.OpenSUSE),
 		photon.NewVulnSrc(),
+		photonoval.NewVulnSrc(),
 		azure.NewVulnSrc(azure.Azure),
 		azure.NewVulnSrc(azure.Mariner),
 		wolfi.NewVulnSrc(),


### PR DESCRIPTION
## Summary

Adds a new vulnerability source `photon-oval` that consumes Photon OS OVAL
advisory files (`photon-oval/{version}/{PHSA-ID}.json`) produced by
vuln-list-update (see aquasecurity/vuln-list-update#408).

### What's new

- `pkg/vulnsrc/photon-oval/` — new `VulnSrc` implementation:
  - Walks `photon-oval/**/*.json`, extracts OS version from the path segment
  - Parses affected packages from the OVAL Criteria tree
    (`"{pkg} is earlier than 0:{ver}"` criterion comments)
  - Stores per-CVE advisory details, vulnerability details and IDs in BoltDB
    using the existing Photon bucket
  - Maps OVAL severity (Critical / Important / Moderate / Low) to `db.Severity`
- Registered in `vulnsrc.All` and `vulnerability.AllSourceIDs`

### Notes

- Lives in parallel with the existing `photon` source — no existing logic touched
- OS version is taken from the **file path**, not from the JSON payload
- Advisory is stored per-CVE (one PHSA → N CVE records)

## Related

- vuln-list-update: aquasecurity/vuln-list-update#408

## Test plan

- [x] `go test ./pkg/vulnsrc/photon-oval/...` passes
- [x] `go build ./...` passes
- [ ] Manual check with a real vuln-list snapshot